### PR TITLE
feature: create comment remover

### DIFF
--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -3,11 +3,12 @@ use core::source_code::Position;
 use core::source_code::SourceCodeCharacter;
 
 #[derive(Debug, PartialEq, Clone)]
-/// A struct that removes comments from the source code
+/// # A struct that removes comments from the source code
 ///
-/// Example:
-/// before: rebind x: int = 0; // this is a comment
-/// after:  rebind x: int = 0;
+/// ## Example:
+/// before: "rebind x: int = 0; // this is a comment"
+///
+/// after:  "rebind x: int = 0; "
 pub struct CommentRemover {
     source: Vec<SourceCodeCharacter>,
     processed: Vec<SourceCodeCharacter>,
@@ -18,17 +19,12 @@ impl CommentRemover {
         source: Vec<SourceCodeCharacter>,
         processed: Vec<SourceCodeCharacter>,
     ) -> CommentRemover {
-        CommentRemover {
-            source,
-            processed,
-        }
+        CommentRemover { source, processed }
     }
 
     pub fn remove(&mut self, reading_comment: bool) -> CommentRemover {
         match self.source.len() {
-            0 => {
-                CommentRemover::new(vec![], self.processed.clone())
-            },
+            0 => CommentRemover::new(vec![], self.processed.clone()),
             1 => {
                 let mut processed = self.processed.clone();
 
@@ -38,7 +34,7 @@ impl CommentRemover {
                 }
 
                 CommentRemover::new(vec![], processed)
-            },
+            }
             _ => {
                 let mut source: Vec<SourceCodeCharacter> = self.source.clone();
                 let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
@@ -91,7 +87,7 @@ mod tests {
             result.push(SourceCodeCharacter::new(
                 ch,
                 Line::new(1).unwrap(),
-                Position::new(position as u32).unwrap()
+                Position::new(position as u32).unwrap(),
             ));
         }
 
@@ -101,36 +97,73 @@ mod tests {
     #[test]
     /// # Test remover pass without comment
     ///
-    /// The source code is: rebind x: int = 0;
-    /// expected: rebind x: int = 0;
+    /// ## Test Case:
+    /// - input source code is: rebind x: int = 0;
+    /// - expected: rebind x: int = 0;
     fn test_remover_pass_without_comment() {
         // Arrange
         let source_text = String::from("rebind x: int = 0;");
-        let source_code = create_source_code_char_factory(source_text.clone());
+        let source_code: Vec<SourceCodeCharacter> =
+            create_source_code_char_factory(source_text.clone());
 
         // Act
         let remover = CommentRemover::new(source_code, vec![]).remove(false);
 
         // Assert
-        let expected = create_source_code_char_factory(source_text);
+        let expected: Vec<SourceCodeCharacter> = create_source_code_char_factory(source_text);
         assert_eq!(remover.processed, expected);
     }
 
     #[test]
-    /// # Test remover pass without comment
+    /// # Test remover pass with comment
     ///
-    /// The source code is: rebind x: int = 0; // this is a comment
-    /// expected: rebind x: int = 0;
+    /// ## Test Case:
+    /// - input source code is: "rebind x: int = 0; // this is a comment"
+    /// - expected: "rebind x: int = 0; "
     fn test_remover_pass_with_comment() {
         // Arrange
         let source_text = String::from("rebind x: int = 0; // this is a comment");
-        let source_code = create_source_code_char_factory(source_text.clone());
+        let source_code: Vec<SourceCodeCharacter> =
+            create_source_code_char_factory(source_text.clone());
 
         // Act
         let remover = CommentRemover::new(source_code, vec![]).remove(false);
 
         // Assert
-        let expected = create_source_code_char_factory("rebind x: int = 0; ".to_string());
+        let expected: Vec<SourceCodeCharacter> =
+            create_source_code_char_factory("rebind x: int = 0; ".to_string());
         assert_eq!(remover.processed, expected);
+    }
+
+    #[test]
+    /// # Test remover pass multiple comments
+    ///
+    /// ## Test Case:
+    /// - input source code is: "rebind x: int = 0; // this is a comment \n 1; // another comment"
+    /// - expected: "rebind x: int = 0; \n 1 "
+    fn test_remover_pass_with_comment_and_newline() {
+        // Arrange
+        let source_text =
+            String::from("rebind x: int = 0; // this is a comment \n 1; // another comment");
+        let source_code: Vec<SourceCodeCharacter> = create_source_code_char_factory(source_text);
+
+        // Act
+        let remover = CommentRemover::new(source_code, vec![]).remove(false);
+
+        // Assert
+        // We need to compare the characters ignoring position, since positions are different after comment removal
+        let expected: Vec<SourceCodeCharacter> =
+            create_source_code_char_factory("rebind x: int = 0; \n 1; ".to_string());
+        assert_eq!(
+            remover
+                .processed
+                .iter()
+                .map(|c| (c.character, c.line.number))
+                .collect::<Vec<_>>(),
+            expected
+                .iter()
+                .map(|c| (c.character, c.line.number))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -1,5 +1,6 @@
+use core::source_code::Line;
+use core::source_code::Position;
 use core::source_code::SourceCodeCharacter;
-
 
 #[derive(Debug, PartialEq, Clone)]
 /// A struct that removes comments from the source code
@@ -13,9 +14,18 @@ pub struct CommentRemover {
 }
 
 impl CommentRemover {
-    pub fn new(source: Vec<SourceCodeCharacter>, processed: Vec<SourceCodeCharacter>) -> CommentRemover {
+    pub fn new(
+        source: Vec<SourceCodeCharacter>,
+        processed: Vec<SourceCodeCharacter>,
+    ) -> CommentRemover {
+        let newline =
+            SourceCodeCharacter::new('\n', Line::new(1).unwrap(), Position::new(1).unwrap());
+        let mut v: Vec<SourceCodeCharacter> = source.clone();
+        v.push(newline.clone());
+        v.push(newline);
+
         CommentRemover {
-            source,
+            source: v,
             processed,
         }
     }
@@ -26,30 +36,31 @@ impl CommentRemover {
                 let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
                 processed.push(self.source.pop().unwrap());
                 CommentRemover::new(vec![], processed)
-            },
+            }
             false => {
-                let mut source = self.source.clone();
-                let first_char = source.remove(0);
-                let second_char = source.remove(0);
-
-                // processing the first character
+                let mut source: Vec<SourceCodeCharacter> = self.source.clone();
                 let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
-                processed.push(first_char.clone());
+                let first_char: SourceCodeCharacter = source.remove(0);
 
-                // if reading a comment and the first character is not newline, continue
-                if reading_comment && first_char.character != '\n'  {
+                // ignore the first character if it is not a newline character (end of the comment)
+                if reading_comment && first_char.character != '\n' {
                     return CommentRemover::new(source, processed).remove(true);
                 };
-                // if reading a comment and the first character is newline, stop reading the comment
-                if reading_comment && first_char.character == '\n'  {
+
+                processed.push(first_char.clone());
+
+                // newline is the end of the comment
+                if reading_comment && first_char.character == '\n' {
                     return CommentRemover::new(source, processed).remove(false);
                 };
 
                 // processing the second character
+                let second_char: SourceCodeCharacter = source.remove(0);
                 processed.push(second_char.clone());
 
                 // if the first character is a slash, check if the next character is a slash
-                let is_comment_out = first_char.character == '/' && second_char.character == '/';
+                let is_comment_out: bool =
+                    first_char.character == '/' && second_char.character == '/';
                 if is_comment_out {
                     return CommentRemover::new(source, processed).remove(true);
                 };

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -1,5 +1,3 @@
-use core::source_code::Line;
-use core::source_code::Position;
 use core::source_code::SourceCodeCharacter;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -71,11 +69,17 @@ impl CommentRemover {
             }
         }
     }
+
+    pub fn get_processed(&self) -> Vec<SourceCodeCharacter> {
+        self.processed.clone()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::source_code::Line;
+    use core::source_code::Position;
 
     /// Creates a vector of SourceCodeCharacter from a string
     /// Each character will have a Line number of 1 and sequential Position numbers

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -18,24 +18,19 @@ impl CommentRemover {
         source: Vec<SourceCodeCharacter>,
         processed: Vec<SourceCodeCharacter>,
     ) -> CommentRemover {
-        let newline =
-            SourceCodeCharacter::new('\n', Line::new(1).unwrap(), Position::new(1).unwrap());
-        let mut v: Vec<SourceCodeCharacter> = source.clone();
-        v.push(newline.clone());
-        v.push(newline);
-
         CommentRemover {
-            source: v,
+            source,
             processed,
         }
     }
 
     pub fn remove(&mut self, reading_comment: bool) -> CommentRemover {
-        match self.source.len() == 1 {
+        match self.source.len() <= 1 {
             true => {
-                let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
-                processed.push(self.source.pop().unwrap());
-                CommentRemover::new(vec![], processed)
+                if reading_comment {
+                    return CommentRemover::new(vec![], self.processed.clone());
+                }
+                CommentRemover::new(vec![], self.processed.clone())
             }
             false => {
                 let mut source: Vec<SourceCodeCharacter> = self.source.clone();
@@ -68,5 +63,66 @@ impl CommentRemover {
                 CommentRemover::new(source, processed).remove(false)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// # Test remover pass without comment
+    ///
+    /// The source code is: rebind x: int = 0;
+    /// expected: rebind x: int = 0;
+    fn test_remover_pass_without_comment() {
+        // Arrange
+        let source_code: Vec<SourceCodeCharacter> = vec![
+            SourceCodeCharacter::new('r', Line::new(1).unwrap(), Position::new(1).unwrap()),
+            SourceCodeCharacter::new('e', Line::new(1).unwrap(), Position::new(2).unwrap()),
+            SourceCodeCharacter::new('b', Line::new(1).unwrap(), Position::new(3).unwrap()),
+            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(4).unwrap()),
+            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(5).unwrap()),
+            SourceCodeCharacter::new('d', Line::new(1).unwrap(), Position::new(6).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(7).unwrap()),
+            SourceCodeCharacter::new('x', Line::new(1).unwrap(), Position::new(8).unwrap()),
+            SourceCodeCharacter::new(':', Line::new(1).unwrap(), Position::new(9).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(10).unwrap()),
+            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(11).unwrap()),
+            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(12).unwrap()),
+            SourceCodeCharacter::new('t', Line::new(1).unwrap(), Position::new(13).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(14).unwrap()),
+            SourceCodeCharacter::new('=', Line::new(1).unwrap(), Position::new(15).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(16).unwrap()),
+            SourceCodeCharacter::new('0', Line::new(1).unwrap(), Position::new(17).unwrap()),
+            SourceCodeCharacter::new(';', Line::new(1).unwrap(), Position::new(18).unwrap()),
+        ];
+
+        // Act
+        let remover = CommentRemover::new(source_code, vec![]).remove(false);
+
+        // Assert
+        let expected: Vec<SourceCodeCharacter> = vec![
+            SourceCodeCharacter::new('r', Line::new(1).unwrap(), Position::new(1).unwrap()),
+            SourceCodeCharacter::new('e', Line::new(1).unwrap(), Position::new(2).unwrap()),
+            SourceCodeCharacter::new('b', Line::new(1).unwrap(), Position::new(3).unwrap()),
+            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(4).unwrap()),
+            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(5).unwrap()),
+            SourceCodeCharacter::new('d', Line::new(1).unwrap(), Position::new(6).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(7).unwrap()),
+            SourceCodeCharacter::new('x', Line::new(1).unwrap(), Position::new(8).unwrap()),
+            SourceCodeCharacter::new(':', Line::new(1).unwrap(), Position::new(9).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(10).unwrap()),
+            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(11).unwrap()),
+            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(12).unwrap()),
+            SourceCodeCharacter::new('t', Line::new(1).unwrap(), Position::new(13).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(14).unwrap()),
+            SourceCodeCharacter::new('=', Line::new(1).unwrap(), Position::new(15).unwrap()),
+            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(16).unwrap()),
+            SourceCodeCharacter::new('0', Line::new(1).unwrap(), Position::new(17).unwrap()),
+            SourceCodeCharacter::new(';', Line::new(1).unwrap(), Position::new(18).unwrap()),
+        ];
+
+        assert_eq!(remover.processed, expected);
     }
 }

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -1,0 +1,61 @@
+use core::source_code::SourceCodeCharacter;
+
+
+#[derive(Debug, PartialEq, Clone)]
+/// A struct that removes comments from the source code
+///
+/// Example:
+/// before: rebind x: int = 0; // this is a comment
+/// after:  rebind x: int = 0;
+pub struct CommentRemover {
+    source: Vec<SourceCodeCharacter>,
+    processed: Vec<SourceCodeCharacter>,
+}
+
+impl CommentRemover {
+    pub fn new(source: Vec<SourceCodeCharacter>, processed: Vec<SourceCodeCharacter>) -> CommentRemover {
+        CommentRemover {
+            source,
+            processed,
+        }
+    }
+
+    pub fn remove(&mut self, reading_comment: bool) -> CommentRemover {
+        match self.source.len() == 1 {
+            true => {
+                let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
+                processed.push(self.source.pop().unwrap());
+                CommentRemover::new(vec![], processed)
+            },
+            false => {
+                let mut source = self.source.clone();
+                let first_char = source.remove(0);
+                let second_char = source.remove(0);
+
+                // processing the first character
+                let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
+                processed.push(first_char.clone());
+
+                // if reading a comment and the first character is not newline, continue
+                if reading_comment && first_char.character != '\n'  {
+                    return CommentRemover::new(source, processed).remove(true);
+                };
+                // if reading a comment and the first character is newline, stop reading the comment
+                if reading_comment && first_char.character == '\n'  {
+                    return CommentRemover::new(source, processed).remove(false);
+                };
+
+                // processing the second character
+                processed.push(second_char.clone());
+
+                // if the first character is a slash, check if the next character is a slash
+                let is_comment_out = first_char.character == '/' && second_char.character == '/';
+                if is_comment_out {
+                    return CommentRemover::new(source, processed).remove(true);
+                };
+
+                CommentRemover::new(source, processed).remove(false)
+            }
+        }
+    }
+}

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -25,41 +25,52 @@ impl CommentRemover {
     }
 
     pub fn remove(&mut self, reading_comment: bool) -> CommentRemover {
-        match self.source.len() <= 1 {
-            true => {
-                if reading_comment {
-                    return CommentRemover::new(vec![], self.processed.clone());
-                }
+        match self.source.len() {
+            0 => {
                 CommentRemover::new(vec![], self.processed.clone())
-            }
-            false => {
+            },
+            1 => {
+                let mut processed = self.processed.clone();
+
+                // If we're not in a comment, include the last character
+                if !reading_comment {
+                    processed.push(self.source[0].clone());
+                }
+
+                CommentRemover::new(vec![], processed)
+            },
+            _ => {
                 let mut source: Vec<SourceCodeCharacter> = self.source.clone();
                 let mut processed: Vec<SourceCodeCharacter> = self.processed.clone();
+
+                if reading_comment {
+                    let first_char: SourceCodeCharacter = source.remove(0);
+
+                    // newline is the end of the comment
+                    if first_char.character == '\n' {
+                        processed.push(first_char.clone());
+                        return CommentRemover::new(source, processed).remove(false);
+                    }
+
+                    // skip the first character
+                    return CommentRemover::new(source, processed).remove(true);
+                }
+
+                // Not in comment mode - check if this could be a comment start
+                if source[0].character == '/' && source.len() >= 2 && source[1].character == '/' {
+                    // Found a comment start - remove both slashes
+                    source.remove(0); // Remove first slash
+                    source.remove(0); // Remove second slash
+
+                    // Enter comment mode without adding slashes to processed
+                    return CommentRemover::new(source, processed).remove(true);
+                }
+
+                // Not a comment or comment start - add the first character to processed
                 let first_char: SourceCodeCharacter = source.remove(0);
+                processed.push(first_char);
 
-                // ignore the first character if it is not a newline character (end of the comment)
-                if reading_comment && first_char.character != '\n' {
-                    return CommentRemover::new(source, processed).remove(true);
-                };
-
-                processed.push(first_char.clone());
-
-                // newline is the end of the comment
-                if reading_comment && first_char.character == '\n' {
-                    return CommentRemover::new(source, processed).remove(false);
-                };
-
-                // processing the second character
-                let second_char: SourceCodeCharacter = source.remove(0);
-                processed.push(second_char.clone());
-
-                // if the first character is a slash, check if the next character is a slash
-                let is_comment_out: bool =
-                    first_char.character == '/' && second_char.character == '/';
-                if is_comment_out {
-                    return CommentRemover::new(source, processed).remove(true);
-                };
-
+                // Continue processing
                 CommentRemover::new(source, processed).remove(false)
             }
         }
@@ -102,6 +113,24 @@ mod tests {
 
         // Assert
         let expected = create_source_code_char_factory(source_text);
+        assert_eq!(remover.processed, expected);
+    }
+
+    #[test]
+    /// # Test remover pass without comment
+    ///
+    /// The source code is: rebind x: int = 0; // this is a comment
+    /// expected: rebind x: int = 0;
+    fn test_remover_pass_with_comment() {
+        // Arrange
+        let source_text = String::from("rebind x: int = 0; // this is a comment");
+        let source_code = create_source_code_char_factory(source_text.clone());
+
+        // Act
+        let remover = CommentRemover::new(source_code, vec![]).remove(false);
+
+        // Assert
+        let expected = create_source_code_char_factory("rebind x: int = 0; ".to_string());
         assert_eq!(remover.processed, expected);
     }
 }

--- a/lib/scanner/src/comment_remover.rs
+++ b/lib/scanner/src/comment_remover.rs
@@ -70,6 +70,23 @@ impl CommentRemover {
 mod tests {
     use super::*;
 
+    /// Creates a vector of SourceCodeCharacter from a string
+    /// Each character will have a Line number of 1 and sequential Position numbers
+    fn create_source_code_char_factory(text: String) -> Vec<SourceCodeCharacter> {
+        let mut result = Vec::with_capacity(text.len());
+
+        for (i, ch) in text.chars().enumerate() {
+            let position = i + 1; // Position is 1-indexed
+            result.push(SourceCodeCharacter::new(
+                ch,
+                Line::new(1).unwrap(),
+                Position::new(position as u32).unwrap()
+            ));
+        }
+
+        result
+    }
+
     #[test]
     /// # Test remover pass without comment
     ///
@@ -77,52 +94,14 @@ mod tests {
     /// expected: rebind x: int = 0;
     fn test_remover_pass_without_comment() {
         // Arrange
-        let source_code: Vec<SourceCodeCharacter> = vec![
-            SourceCodeCharacter::new('r', Line::new(1).unwrap(), Position::new(1).unwrap()),
-            SourceCodeCharacter::new('e', Line::new(1).unwrap(), Position::new(2).unwrap()),
-            SourceCodeCharacter::new('b', Line::new(1).unwrap(), Position::new(3).unwrap()),
-            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(4).unwrap()),
-            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(5).unwrap()),
-            SourceCodeCharacter::new('d', Line::new(1).unwrap(), Position::new(6).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(7).unwrap()),
-            SourceCodeCharacter::new('x', Line::new(1).unwrap(), Position::new(8).unwrap()),
-            SourceCodeCharacter::new(':', Line::new(1).unwrap(), Position::new(9).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(10).unwrap()),
-            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(11).unwrap()),
-            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(12).unwrap()),
-            SourceCodeCharacter::new('t', Line::new(1).unwrap(), Position::new(13).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(14).unwrap()),
-            SourceCodeCharacter::new('=', Line::new(1).unwrap(), Position::new(15).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(16).unwrap()),
-            SourceCodeCharacter::new('0', Line::new(1).unwrap(), Position::new(17).unwrap()),
-            SourceCodeCharacter::new(';', Line::new(1).unwrap(), Position::new(18).unwrap()),
-        ];
+        let source_text = String::from("rebind x: int = 0;");
+        let source_code = create_source_code_char_factory(source_text.clone());
 
         // Act
         let remover = CommentRemover::new(source_code, vec![]).remove(false);
 
         // Assert
-        let expected: Vec<SourceCodeCharacter> = vec![
-            SourceCodeCharacter::new('r', Line::new(1).unwrap(), Position::new(1).unwrap()),
-            SourceCodeCharacter::new('e', Line::new(1).unwrap(), Position::new(2).unwrap()),
-            SourceCodeCharacter::new('b', Line::new(1).unwrap(), Position::new(3).unwrap()),
-            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(4).unwrap()),
-            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(5).unwrap()),
-            SourceCodeCharacter::new('d', Line::new(1).unwrap(), Position::new(6).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(7).unwrap()),
-            SourceCodeCharacter::new('x', Line::new(1).unwrap(), Position::new(8).unwrap()),
-            SourceCodeCharacter::new(':', Line::new(1).unwrap(), Position::new(9).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(10).unwrap()),
-            SourceCodeCharacter::new('i', Line::new(1).unwrap(), Position::new(11).unwrap()),
-            SourceCodeCharacter::new('n', Line::new(1).unwrap(), Position::new(12).unwrap()),
-            SourceCodeCharacter::new('t', Line::new(1).unwrap(), Position::new(13).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(14).unwrap()),
-            SourceCodeCharacter::new('=', Line::new(1).unwrap(), Position::new(15).unwrap()),
-            SourceCodeCharacter::new(' ', Line::new(1).unwrap(), Position::new(16).unwrap()),
-            SourceCodeCharacter::new('0', Line::new(1).unwrap(), Position::new(17).unwrap()),
-            SourceCodeCharacter::new(';', Line::new(1).unwrap(), Position::new(18).unwrap()),
-        ];
-
+        let expected = create_source_code_char_factory(source_text);
         assert_eq!(remover.processed, expected);
     }
 }

--- a/lib/scanner/src/lib.rs
+++ b/lib/scanner/src/lib.rs
@@ -1,5 +1,5 @@
-mod source_stream_generator;
 mod comment_remover;
+mod source_stream_generator;
 
 use log::debug;
 use source_stream_generator::SourceStreamGenerator;

--- a/lib/scanner/src/lib.rs
+++ b/lib/scanner/src/lib.rs
@@ -1,4 +1,5 @@
 mod source_stream_generator;
+mod comment_remover;
 
 use log::debug;
 use source_stream_generator::SourceStreamGenerator;

--- a/lib/scanner/src/lib.rs
+++ b/lib/scanner/src/lib.rs
@@ -1,6 +1,7 @@
 mod comment_remover;
 mod source_stream_generator;
 
+use comment_remover::CommentRemover;
 use log::debug;
 use source_stream_generator::SourceStreamGenerator;
 
@@ -19,5 +20,8 @@ impl Scanner {
         let stream_generator =
             SourceStreamGenerator::new(self.source_code.clone(), vec![], None, None).generate();
         debug!("{:?}", stream_generator.get_processed());
+        let comment_remover =
+            CommentRemover::new(stream_generator.get_processed(), vec![]).remove(false);
+        debug!("{:?}", comment_remover.get_processed());
     }
 }


### PR DESCRIPTION
## About

I implemented comment remover.

```
./target/debug/polix -o "a // hoge" -d                                                              ~/Hobby/polix
[2025-03-10T13:13:41Z DEBUG polix] Request { debug: true, command: RunAtOnce("a // hoge") }
[2025-03-10T13:13:41Z DEBUG polix::controller::run_interpreter_at_once] Running interpreter at once
[2025-03-10T13:13:41Z DEBUG polix::controller::run_interpreter_at_once] Source code: a // hoge
[2025-03-10T13:13:41Z DEBUG scanner] [SourceCodeCharacter { character: 'a', line: Line { number: 1 }, position: Position { number: 1 } }, SourceCodeCharacter { character: ' ', line: Line { number: 1 }, position: Position { number: 2 } }, SourceCodeCharacter { character: '/', line: Line { number: 1 }, position: Position { number: 3 } }, SourceCodeCharacter { character: '/', line: Line { number: 1 }, position: Position { number: 4 } }, SourceCodeCharacter { character: ' ', line: Line { number: 1 }, position: Position { number: 5 } }, SourceCodeCharacter { character: 'h', line: Line { number: 1 }, position: Position { number: 6 } }, SourceCodeCharacter { character: 'o', line: Line { number: 1 }, position: Position { number: 7 } }, SourceCodeCharacter { character: 'g', line: Line { number: 1 }, position: Position { number: 8 } }, SourceCodeCharacter { character: 'e', line: Line { number: 1 }, position: Position { number: 9 } }]
[2025-03-10T13:13:41Z DEBUG scanner] [SourceCodeCharacter { character: 'a', line: Line { number: 1 }, position: Position { number: 1 } }, SourceCodeCharacter { character: ' ', line: Line { number: 1 }, position: Position { number: 2 } }]
[2025-03-10T13:13:41Z DEBUG polix::controller::run_interpreter_at_once] Source code scanner finished
```

## Test

```shell
   Compiling scanner v0.1.0 (/Users/shunsuke.tsuchiya/Hobby/polix/lib/scanner)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.49s
     Running unittests src/lib.rs (target/debug/deps/scanner-5a84b772e1f9381d)

running 5 tests
test source_stream_generator::tests::test_parse_source_code_with_newline ... ok
test source_stream_generator::tests::test_parse_source_code_without_newline ... ok
test comment_remover::tests::test_remover_pass_without_comment ... ok
test comment_remover::tests::test_remover_pass_with_comment ... ok
test comment_remover::tests::test_remover_pass_with_comment_and_newline ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests scanner

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
